### PR TITLE
update to alpine 3.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM alpine:3.11 as builder
+FROM alpine:3.15 as builder
 
 ARG VCS_REF
 ARG BUILD_DATE
@@ -32,10 +32,10 @@ RUN \
     build-base \
     curl \
     git \
-    nodejs-npm \
+    npm \
     nodejs \
     openssl \
-    python
+    python3
 
 WORKDIR /data
 
@@ -86,7 +86,7 @@ RUN \
 
 # ---------------------------------------------------------------------------------------
 
-FROM alpine:3.11
+FROM alpine:3.15
 
 ENV \
   TZ='Europe/Berlin'


### PR DESCRIPTION
This updates the docker container to build on the latest alpine, v3.15

Tested and working as of last week, didn't fix my issue with TLS connections to quassel backends with updated letsencrypt certificates though. :(